### PR TITLE
Changing API

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -7,7 +7,8 @@
       ],
       "parserOptions": {
         "project": [
-          "./tsconfig.json"
+          "./tsconfig.json",
+          "./tsconfig.jest.json"
         ]
       }
     },

--- a/README.md
+++ b/README.md
@@ -22,14 +22,14 @@ yarn install ts-error-as-value
 ```ts
 import "ts-error-as-value/lib/globals";
 ```
-This will make the functions ok, fail and withResult, as well as the types Ok, Fail and Result globally available
+This will make the functions ResultIs.success, ResultIs.failure and withResult, as well as the types Success, Failure and Result globally available
 
 ---
 
-## ok and fail - Basic Usage
-Creating `Ok` and `Fail` result objects
+## ResultIs.success and ResultIs.failure - Basic Usage
+Creating `Success` and `Failure` result objects
 ```ts
-const { data, error } = ok("Hello");
+const { data, error } = ResultIs.success("Hello");
 if (error) {
   // do something with error
 } else {
@@ -37,24 +37,27 @@ if (error) {
 }
 ```
 or
+
 ```ts
-const { data, error } = fail(new Error("Error"));
+
+const {data, error} = ResultIs.failure(new Error("Error"));
 if (error) {
-  // do something with error
+ // do something with error
 } else {
-  // do something with data
+ // do something with data
 }
 ```
 ---
 
-Wrapping the returns from functions with `fail` for errors, and `ok` for non-error so that the function calling it receives a `Result` type.
+Wrapping the returns from functions with `ResultIs.failure` for errors, and `ResultIs.success` for non-error so that the function calling it receives a `Result` type.
 
 ```ts
+// Specifying the return type here is optional, as it will be inferred without it
 const fnWithResult = (): Result<string, Error> => {
   if ("" !== "") {
-    return ok("hello");
+    return ResultIs.success("hello");
   }
-  return fail(new Error("Method failed"));
+  return ResultIs.failure(new Error("Method failed"));
 };
 
 const { data, error } = fnWithResult();
@@ -71,17 +74,17 @@ Or with promises:
 ```ts
 const fnWithResult = async (): Promise<Result<string, Error>> => {
   if ("" !== "") {
-    return ok("hello");
+    return ResultIs.success("hello");
   }
-  return fail(new Error("Method failed"));
+  return ResultIs.failure(new Error("Method failed"));
 };
 
 const callsFnThatCallsFnWithResult = async () => {
   const { data, error, errorStack } = (await fnWithResult())
   if (error) {
-    return fail(error);
+    return ResultIs.failure(error);
   }
-  return ok(data);
+  return ResultIs.success(data);
 };
 
 callsFnThatCallsFnWithResult();
@@ -96,9 +99,9 @@ class NewError extends Error {}
 
 const fnWithResult = (): Result<string, Error> => {
   if ("" !== "") {
-    return ok("hello");
+    return ResultIs.success("hello");
   }
-  return fail(new Error("Method failed"));
+  return ResultIs.failure(new Error("Method failed"));
 };
 
 const callsFnThatCallsFnWithResult = async (): Promise<Result<boolean, NewError>> => {
@@ -110,9 +113,9 @@ const callsFnThatCallsFnWithResult = async (): Promise<Result<boolean, NewError>
       return data === "hello";
     });
   if (error) {
-    return fail(error);
+    return ResultIs.failure(error);
   }
-  return ok(data);
+  return ResultIs.success(data);
 };
 ```
 
@@ -121,8 +124,8 @@ const callsFnThatCallsFnWithResult = async (): Promise<Result<boolean, NewError>
 ## withResult
 *One downside to using a system where errors are treated as values in javascript is that you have no control over whether a third party dependency will throw errors or not. As a result, we need a way to wrap functions that can throw errors and force them to return a result for us.*
 
-withResult is a function which wraps another function and returns an `Err` result if the wrapped function throws an error,
- or an `Ok` result if the wrapped function does not.
+withResult is a function which wraps another function and returns a `Failure` result if the wrapped function throws an error,
+ or a `Success` result if the wrapped function does not.
 ```ts
 import somePkg from "package-that-throws-errors";
 
@@ -140,33 +143,35 @@ if (error) {
 ## API
 
 ```typescript
-export type Fail<E extends Error = Error> = {
+export type Failure<E extends Error = Error> = {
   data: null,
   error: E,
-  unwrap(): void, // Returns the value, but throws an error if the result is an Error
-  unwrapOr<D>(defaultValue: D): D, // Returns the value or gives you a default value if it's an error
-  mapFail<E2 extends Error>(fn: (fail: E) => E2): Fail<E2>, // If the result is an error, map the error to another error
-  andThen<N>(fn: (data: never) => N): Fail<E> // If the result is not an error, map the data in it
+  successOrThrow(): void, // Returns the value, but throws an error if the result is an Error
+  successOrDefault<D>(defaultValue: D): D, // Returns the value or gives you a default value if it's an error
+  transformOnFailure<E2 extends Error>(fn: (fail: E) => E2): Failure<E2>, // If the result is an error, map the error to another error
+  transformOnSuccess<N>(fn: (data: never) => N): Failure<E> // If the result is not an error, map the data in it
 };
 
-export type Ok<T> = {
+export type Success<T> = {
   data: T,
   error: null,
-  unwrap(): T, // Returns the value, but throws an error if the result is an Error
-  unwrapOr<D>(defaultValue: D): T, // Returns the value or gives you a default value if it's an error
-  mapFail<E2 extends Error>(fn: (fail: never) => E2): Ok<T>, // If the result is an error, map the error to another error
-  andThen<N>(fn: (data: T) => N): Ok<N> // If the result is not an error, map the data in it
+  successOrThrow(): T, // Returns the value, but throws an error if the result is an Error
+  successOrDefault<D>(defaultValue: D): T, // Returns the value or gives you a default value if it's an error
+  transformOnFailure<E2 extends Error>(fn: (fail: never) => E2): Success<T>, // If the result is an error, map the error to another error
+  transformOnSuccess<N>(fn: (data: T) => N): Success<N> // If the result is not an error, map the data in it
 };
 
 export type Result<
   T, E extends Error = Error
-> = Fail<E> | Ok<T>;
+> = Failure<E> | Success<T>;
 
 ```
 
 ```ts
-function fail<E extends Error>(error: E): Fail<E>;
-function ok<T>(data: T): Ok<T>;
+export type ResultIs = {
+  success<T>(data: T): Success<T>,
+  failure<E extends Error>(failure: E): Failure<E>
+};
 ```
 
 ```ts

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-error-as-value",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "description": "Errors as values in typescript",
   "main": "lib/index.js",
   "keywords": ["result", "option", "rust", "kotlin", "errors", "errors as values", "typescript"],

--- a/src/globals.d.ts
+++ b/src/globals.d.ts
@@ -1,12 +1,14 @@
 
-type Ok<T> = import(".").Ok<T>;
-type Fail<E extends Error> = import(".").Fail<E>;
+type Success<T> = import(".").Success<T>;
+type Failure<E extends Error> = import(".").Failure<E>;
 type Result<T, E extends Error> = import(".").Result<T, E>;
+declare class ResultIs {
+  static success: <T>(data: T) => Success<T>;
+  static failure: <E extends Error>(failure: E) => Failure<E>;
+}
 
-declare function ok<T>(data: T): Ok<T>;
-declare function fail<E extends Error>(error: E): Fail<E>
 declare function withResult<T, E extends Error, R>(
   fn: (...args: T[]) => R
 ): (
   ...args: T[]
-) => R extends Promise<infer u> ? Promise<Result<u, E>> : Result<R, E>
+) => R extends Promise<infer u> ? Promise<Result<u, E>> : Result<R, E>;

--- a/src/globals.ts
+++ b/src/globals.ts
@@ -1,12 +1,10 @@
-import { ok, fail } from ".";
+import { ResultIs } from ".";
 import { withResult } from "./with-result";
 
 if (typeof window !== "undefined") {
-  (window as any).ok = ok;
-  (window as any).fail = fail;
+  (window as any).ResultIs = ResultIs;
   (window as any).withResult = withResult;
 } else {
-  (globalThis as any).ok = ok;
-  (globalThis as any).fail = fail;
+  (globalThis as any).ResultIs = ResultIs;
   (globalThis as any).withResult = withResult;
 }

--- a/src/index.unit.test.ts
+++ b/src/index.unit.test.ts
@@ -1,4 +1,4 @@
-import { fail, Fail, Result, Ok, ok } from "../src";
+import { ResultIs, Failure, Result, Success } from "../src";
 
 
 describe("Result", () => {
@@ -8,37 +8,37 @@ describe("Result", () => {
     const testError = new Error("Test error");
 
     beforeEach(() => {
-      errorInstance = fail(testError);
+      errorInstance = ResultIs.failure(testError);
     });
 
     it("should throw error on unwrap for Err type", () => {
-      expect(() => errorInstance.unwrap()).toThrow(testError);
+      expect(() => errorInstance.successOrThrow()).toThrow(testError);
     });
 
     it("should return default value on unwrapOr for Err type", () => {
-      expect(errorInstance.unwrapOr("default")).toBe("default");
+      expect(errorInstance.successOrDefault("default")).toBe("default");
     });
 
     it("should map error using mapErr for Err type", () => {
       const newError = new Error("New error");
-      const { error } = errorInstance.mapFail(() => newError);
+      const { error } = errorInstance.transformOnFailure(() => newError);
       if (error) {
         expect(error.message).toBe(newError.message);
       }
     });
 
     it("should return itself on andThen for Err type", () => {
-      const result = errorInstance.andThen(() => "new value");
+      const result = errorInstance.transformOnSuccess(() => "new value");
       expect(JSON.stringify(result)).toEqual(JSON.stringify(errorInstance));
     });
   });
 
   describe("Ok type", () => {
-    let okInstance: Ok<string>;
+    let okInstance: Success<string>;
     const testData = "test data";
 
     beforeEach(() => {
-      okInstance = ok(testData);
+      okInstance = ResultIs.success(testData);
     });
 
     it("should return data for Ok type", () => {
@@ -50,22 +50,22 @@ describe("Result", () => {
     });
 
     it("should return data on unwrap for Ok type", () => {
-      expect(okInstance.unwrap()).toBe(testData);
+      expect(okInstance.successOrThrow()).toBe(testData);
     });
 
     it("should return data on unwrapOr for Ok type", () => {
-      expect(okInstance.unwrapOr("default")).toBe(testData);
+      expect(okInstance.successOrDefault("default")).toBe(testData);
     });
 
     it("should return itself on mapErr for Ok type", () => {
-      const result = okInstance.mapFail(() => new Error("New error"));
+      const result = okInstance.transformOnFailure(() => new Error("New error"));
       expect(JSON.stringify(result)).toEqual(JSON.stringify(okInstance));
     });
 
     it("should execute andThen and return new Ok type", () => {
       const newValue = "new value";
-      const result = okInstance.andThen(() => newValue);
-      expect(JSON.stringify(result)).toEqual(JSON.stringify(ok(newValue)));
+      const result = okInstance.transformOnSuccess(() => newValue);
+      expect(JSON.stringify(result)).toEqual(JSON.stringify(ResultIs.success(newValue)));
       expect(result.data).toBe(newValue);
     });
   });

--- a/src/with-result.ts
+++ b/src/with-result.ts
@@ -1,4 +1,4 @@
-import { fail, ok, Result, Ok, Fail } from "./index";
+import { ResultIs, Result, Success, Failure } from "./index";
 
 export const isPromise = <T>(value: T | Promise<T>): value is Promise<T> =>
   (value as any).then != null;
@@ -14,13 +14,13 @@ export const withResult = <T, E extends Error, R>(
     const data = fn(...args);
     if (isPromise(data)) {
       return data
-        .then(value => ok(value) as Ok<typeof value>)
-        .catch(e => fail(e) as Fail<E>) as (R extends Promise<infer u> ? Promise<Result<u, E>> : Result<R, E>);
+        .then(value => ResultIs.success(value) as Success<typeof value>)
+        .catch(e => ResultIs.failure(e) as Failure<E>) as (R extends Promise<infer u> ? Promise<Result<u, E>> : Result<R, E>);
     }
-    return ok(data) as any;
+    return ResultIs.success(data) as any;
   } catch (error) {
     const e = error instanceof Error ? error : new Error("Unknown error");
-    return fail(e) as any;
+    return ResultIs.failure(e) as any;
   }
 };
 

--- a/src/with-result.unit.test.ts
+++ b/src/with-result.unit.test.ts
@@ -1,5 +1,5 @@
 // Assuming a jest-like syntax for demonstration purposes.
-import { ok, Result } from "../src";
+import { ResultIs, Result } from "../src";
 import { withResult, isPromise } from "./with-result";
 
 describe("isPromise", () => {
@@ -20,7 +20,7 @@ describe("withResult", () => {
     it("should return Ok for successful executions", () => {
       const func = (n: number) => n + 1;
       const wrapped = withResult(func);
-      expect(JSON.stringify(wrapped(1))).toStrictEqual(JSON.stringify(ok(2)));
+      expect(JSON.stringify(wrapped(1))).toStrictEqual(JSON.stringify(ResultIs.success(2)));
     });
 
     it("should return Fail for errors", () => {
@@ -38,7 +38,7 @@ describe("withResult", () => {
       const asyncFunc = async (n: number) => n + 1;
       const wrapped = withResult(asyncFunc);
       const result = await wrapped(1);
-      expect(JSON.stringify(result)).toEqual(JSON.stringify(ok(2)));
+      expect(JSON.stringify(result)).toEqual(JSON.stringify(ResultIs.success(2)));
     });
 
     it("should return Fail for rejected promises", async () => {


### PR DESCRIPTION
Changing API:

ok -> ResultIs.success
fail -> ResultIs.failure
unwrapOr -> successOrDefault
unwrap -> successOrThrow
type Ok -> type Success
type Fail -> type Failure 

See this discussion for more information about why: https://rollcredits.slack.com/archives/C04PG6VHLMQ/p1691614976267589