### PR TITLE
Adding defaults to Result generics, and no argument to ResultIs.success

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-error-as-value",
-  "version": "0.1.9",
+  "version": "0.2.0",
   "description": "Errors as values in typescript",
   "main": "lib/index.js",
   "keywords": ["result", "option", "rust", "kotlin", "errors", "errors as values", "typescript"],

--- a/src/globals.d.ts
+++ b/src/globals.d.ts
@@ -1,8 +1,10 @@
 
 type Success<T> = import(".").Success<T>;
 type Failure<E extends Error> = import(".").Failure<E>;
-type Result<T, E extends Error> = import(".").Result<T, E>;
+type Result<T = void, E extends Error = Error> = import(".").Result<T, E>;
 declare class ResultIs {
+  // If no argument is given to success, assume the success result type is void
+  static success: () => Success<void>;
   static success: <T>(data: T) => Success<T>;
   static failure: <E extends Error>(failure: E) => Failure<E>;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,7 @@ export type Failure<E extends Error = Error> = {
   transformOnSuccess<N>(fn: (data: never) => N): Failure<E> // If the result is not an error, map the data in it
 };
 
-export type Success<T> = {
+export type Success<T = void> = {
   data: T,
   error: null,
   successOrThrow(): T, // Returns the value, but throws an error if the result is an Error
@@ -19,45 +19,52 @@ export type Success<T> = {
 };
 
 export type Result<
-  T, E extends Error = Error
+  T = void, E extends Error = Error
 > = Failure<E> | Success<T>;
 
-const failure = <E extends Error>(
+function failure<E extends Error>(
   error: E
-): Failure<E> => ({
-  data: null,
-  error: error,
-  successOrThrow() {
-    throw error;
-  },
-  successOrDefault<D>(defaultValue: D): D {
-    return defaultValue;
-  },
-  transformOnFailure<E2 extends Error>(fn: (err: E) => E2): Failure<E2> {
-    return failure<E2>(fn(error));
-  },
-  transformOnSuccess(): Failure<E> {
-    return this;
-  }
-});
-const success = <T>(
-  data: T
-): Success<T> => ({
-  data,
-  error: null,
-  successOrThrow(): T {
-    return data;
-  },
-  successOrDefault(): T {
-    return data;
-  },
-  transformOnFailure(): Success<T> {
-    return this;
-  },
-  transformOnSuccess<N>(fn: (data: T) => N): Success<N> {
-    return success(fn(data));
-  }
-});
+): Failure<E> {
+  return {
+    data: null,
+    error: error,
+    successOrThrow() {
+      throw error;
+    },
+    successOrDefault<D>(defaultValue: D): D {
+      return defaultValue;
+    },
+    transformOnFailure<E2 extends Error>(fn: (err: E) => E2): Failure<E2> {
+      return failure<E2>(fn(error));
+    },
+    transformOnSuccess(): Failure<E> {
+      return this;
+    }
+  };
+}
+
+function success(): Success;
+function success<T>(data: T): Success<T>;
+function success<T = void>(
+  data: T = undefined as T
+): Success<T> {
+  return {
+    data: data,
+    error: null,
+    successOrThrow(): T {
+      return data as T;
+    },
+    successOrDefault(): T {
+      return data as T;
+    },
+    transformOnFailure(): Success<T> {
+      return this;
+    },
+    transformOnSuccess<N>(fn: (data: T) => N): Success<N> {
+      return success(fn(data as T));
+    }
+  };
+}
 
 export type ResultIs = {
   success<T>(data: T): Success<T>,


### PR DESCRIPTION
- Adding defaults to generics for convenience
- Adding ability to pass no argument to ResultIs.success and have it resolve to Result<void, Error>