### PR TITLE
Moving to less verbose method for creating Result objects

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -43,7 +43,6 @@
   },
   "plugins": [
     "eslint-plugin-no-null",
-    "eslint-plugin-jsdoc",
     "@typescript-eslint"
   ],
   "rules": {

--- a/README.md
+++ b/README.md
@@ -22,14 +22,14 @@ yarn install ts-error-as-value
 ```ts
 import "ts-error-as-value/lib/globals";
 ```
-This will make the functions ResultIs.success, ResultIs.failure and withResult, as well as the types Success, Failure and Result globally available
+This will make the functions ok, err and withResult, as well as the types Success, Failure and Result globally available
 
 ---
 
-## ResultIs.success and ResultIs.failure - Basic Usage
+## ok and err - Basic Usage
 Creating `Success` and `Failure` result objects
 ```ts
-const { data, error } = ResultIs.success("Hello");
+const { data, error } = ok("Hello");
 if (error) {
   // do something with error
 } else {
@@ -40,7 +40,7 @@ or
 
 ```ts
 
-const {data, error} = ResultIs.failure(new Error("Error"));
+const {data, error} = err(new Error("Error"));
 if (error) {
  // do something with error
 } else {
@@ -49,15 +49,15 @@ if (error) {
 ```
 ---
 
-Wrapping the returns from functions with `ResultIs.failure` for errors, and `ResultIs.success` for non-error so that the function calling it receives a `Result` type.
+Wrapping the returns from functions with `err` for errors, and `ok` for non-error so that the function calling it receives a `Result` type.
 
 ```ts
 // Specifying the return type here is optional, as it will be inferred without it
 const fnWithResult = (): Result<string, Error> => {
   if ("" !== "") {
-    return ResultIs.success("hello");
+    return ok("hello");
   }
-  return ResultIs.failure(new Error("Method failed"));
+  return err(new Error("Method failed"));
 };
 
 const { data, error } = fnWithResult();
@@ -74,17 +74,17 @@ Or with promises:
 ```ts
 const fnWithResult = async (): Promise<Result<string, Error>> => {
   if ("" !== "") {
-    return ResultIs.success("hello");
+    return ok("hello");
   }
-  return ResultIs.failure(new Error("Method failed"));
+  return err(new Error("Method failed"));
 };
 
 const callsFnThatCallsFnWithResult = async () => {
   const { data, error, errorStack } = (await fnWithResult())
   if (error) {
-    return ResultIs.failure(error);
+    return err(error);
   }
-  return ResultIs.success(data);
+  return ok(data);
 };
 
 callsFnThatCallsFnWithResult();
@@ -99,9 +99,9 @@ class NewError extends Error {}
 
 const fnWithResult = (): Result<string, Error> => {
   if ("" !== "") {
-    return ResultIs.success("hello");
+    return ok("hello");
   }
-  return ResultIs.failure(new Error("Method failed"));
+  return err(new Error("Method failed"));
 };
 
 const callsFnThatCallsFnWithResult = async (): Promise<Result<boolean, NewError>> => {
@@ -113,9 +113,9 @@ const callsFnThatCallsFnWithResult = async (): Promise<Result<boolean, NewError>
       return data === "hello";
     });
   if (error) {
-    return ResultIs.failure(error);
+    return err(error);
   }
-  return ResultIs.success(data);
+  return ok(data);
 };
 ```
 
@@ -168,10 +168,8 @@ export type Result<
 ```
 
 ```ts
-export type ResultIs = {
-  success<T>(data: T): Success<T>,
-  failure<E extends Error>(failure: E): Failure<E>
-};
+declare function ok<T = void>(data?: T): Success<T>;
+declare function err<E extends Error>(error: E): Failure<E>;
 ```
 
 ```ts

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-error-as-value",
-  "version": "0.3.12",
+  "version": "0.4.01",
   "description": "Errors as values in typescript",
   "main": "lib/index.js",
   "keywords": ["result", "option", "rust", "kotlin", "errors", "errors as values", "typescript"],
@@ -28,7 +28,6 @@
     "@typescript-eslint/parser": "^5.39.0",
     "eslint": "^8.25.0",
     "eslint-config-prettier": "^8.5.0",
-    "eslint-plugin-jsdoc": "^39.3.6",
     "eslint-plugin-no-null": "^1.0.2",
     "jest": "^29.2.0",
     "prettier": "^2.7.1",

--- a/src/globals.d.ts
+++ b/src/globals.d.ts
@@ -2,11 +2,9 @@
 type Success<T> = import(".").Success<T>;
 type Failure<E extends Error> = import(".").Failure<any extends infer u ? u : never, E>;
 type Result<T = void, E extends Error = Error> = import(".").Result<T, E>;
-declare class ResultIs {
-  static success: <T = void>(data?: T) => Success<T>;
-  static failure: <E extends Error>(failure: E) => Failure<E>;
-}
 
+declare function ok<T = void>(data?: T): Success<T>;
+declare function err<E extends Error>(error: E): Failure<E>;
 /**
  * @desc Function which wraps another function and returns a new function that has the same argument types as the wrapped function.
  * This new function will return a Fail result if the wrapped function throws an error, and returns an Ok result if the wrapped function does not.

--- a/src/globals.ts
+++ b/src/globals.ts
@@ -1,10 +1,12 @@
-import { ResultIs } from ".";
+import { ok, err } from ".";
 import { withResult } from "./with-result";
 
 if (typeof window !== "undefined") {
-  (window as any).ResultIs = ResultIs;
+  (window as any).err = err;
+  (window as any).ok = ok;
   (window as any).withResult = withResult;
 } else {
-  (globalThis as any).ResultIs = ResultIs;
+  (globalThis as any).err = err;
+  (globalThis as any).ok = ok;
   (globalThis as any).withResult = withResult;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,7 +26,7 @@ export type Result<
   T = void, E extends Error = Error
 > = Failure<T, E> | Success<T>;
 
-function failure<
+export function err<
   T = void,
   E extends Error = Error
 >(
@@ -42,7 +42,7 @@ function failure<
       return defaultValue;
     },
     transformOnFailure<E2 extends Error>(fn: (err: E) => E2): Failure<T, E2> {
-      return failure<T, E2>(fn(error));
+      return err<T, E2>(fn(error));
     },
     transformOnSuccess(): Failure<T, E> {
       return this;
@@ -50,9 +50,9 @@ function failure<
   };
 }
 
-function success(): Success;
-function success<T>(data?: T): Success<T>;
-function success<T = void>(
+export function ok(): Success;
+export function ok<T>(data?: T): Success<T>;
+export function ok<T = void>(
   data: T = undefined as T
 ): Success<T> {
   return {
@@ -68,18 +68,8 @@ function success<T = void>(
       return this;
     },
     transformOnSuccess<N>(fn: (data: T) => N): Success<N> {
-      return success(fn(data as T));
+      return ok(fn(data as T));
     }
   };
 }
-
-export type ResultIs = {
-  success<T>(data?: T): Success<T>,
-  failure<E extends Error = Error>(failure: E): Failure<any extends infer u ? u : never, E>
-};
-
-export const ResultIs: ResultIs = {
-  success,
-  failure
-};
 

--- a/src/index.unit.test.ts
+++ b/src/index.unit.test.ts
@@ -1,4 +1,4 @@
-import { ResultIs, Failure, Result, Success } from "../src";
+import { ok, err, Failure, Result, Success } from "../src";
 
 
 describe("Result", () => {
@@ -8,7 +8,7 @@ describe("Result", () => {
     const testError = new Error("Test error");
 
     beforeEach(() => {
-      errorInstance = ResultIs.failure(testError);
+      errorInstance = err(testError);
     });
 
     it("should throw error on unwrap for Err type", () => {
@@ -38,7 +38,7 @@ describe("Result", () => {
     const testData = "test data";
 
     beforeEach(() => {
-      okInstance = ResultIs.success(testData);
+      okInstance = ok(testData);
     });
 
     it("should return data for Ok type", () => {
@@ -65,7 +65,7 @@ describe("Result", () => {
     it("should execute andThen and return new Ok type", () => {
       const newValue = "new value";
       const result = okInstance.transformOnSuccess(() => newValue);
-      expect(JSON.stringify(result)).toEqual(JSON.stringify(ResultIs.success(newValue)));
+      expect(JSON.stringify(result)).toEqual(JSON.stringify(ok(newValue)));
       expect(result.data).toBe(newValue);
     });
   });

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,3 @@
+
+export const isPromise = <T>(value: T | Promise<T>): value is Promise<T> =>
+  (value as any).then != null;

--- a/src/utils.unit.test.ts
+++ b/src/utils.unit.test.ts
@@ -1,0 +1,14 @@
+import { isPromise } from "./utils";
+
+describe("isPromise", () => {
+  it("should return true for promises", () => {
+    const promise = new Promise((resolve) => setTimeout(() => resolve(true), 0));
+    expect(isPromise(promise)).toBe(true);
+  });
+
+  it("should return false for non-promises", () => {
+    expect(isPromise(123)).toBe(false);
+    expect(isPromise({})).toBe(false);
+    expect(isPromise(() => {})).toBe(false);
+  });
+});

--- a/src/with-result.ts
+++ b/src/with-result.ts
@@ -1,7 +1,6 @@
-import { ResultIs, Result, Success, Failure } from "./index";
+import { ok, err, Result, Success, Failure } from "./index";
+import { isPromise } from "./utils";
 
-export const isPromise = <T>(value: T | Promise<T>): value is Promise<T> =>
-  (value as any).then != null;
 
 /**
  * @desc Function which wraps another function and returns a new function that has the same argument types as the wrapped function.
@@ -29,13 +28,13 @@ export const withResult = <T, E extends Error, R>(
     const data = fnContext ? fn.apply(fnContext, args) : fn(...args);
     if (isPromise(data)) {
       return data
-        .then(value => ResultIs.success(value) as Success<typeof value>)
-        .catch(e => ResultIs.failure(e) as Failure<E>) as (R extends Promise<infer u> ? Promise<Result<u, E>> : Result<R, E>);
+        .then(value => ok(value) as Success<typeof value>)
+        .catch(e => err(e) as Failure<E>) as (R extends Promise<infer u> ? Promise<Result<u, E>> : Result<R, E>);
     }
-    return ResultIs.success(data) as any;
+    return ok(data) as any;
   } catch (error) {
     const e = error instanceof Error ? error : new Error("Unknown error");
-    return ResultIs.failure(e) as any;
+    return err(e) as any;
   }
 };
 

--- a/src/with-result.unit.test.ts
+++ b/src/with-result.unit.test.ts
@@ -1,26 +1,15 @@
 // Assuming a jest-like syntax for demonstration purposes.
-import { ResultIs, Result } from "../src";
-import { withResult, isPromise } from "./with-result";
+import { ok, err, Result } from "../src";
+import { withResult } from "./with-result";
 
-describe("isPromise", () => {
-  it("should return true for promises", () => {
-    const promise = new Promise((resolve) => setTimeout(() => resolve(true), 0));
-    expect(isPromise(promise)).toBe(true);
-  });
 
-  it("should return false for non-promises", () => {
-    expect(isPromise(123)).toBe(false);
-    expect(isPromise({})).toBe(false);
-    expect(isPromise(() => {})).toBe(false);
-  });
-});
 
 describe("withResult", () => {
   describe("for synchronous functions", () => {
     it("should return Ok for successful executions", () => {
       const func = (n: number) => n + 1;
       const wrapped = withResult(func);
-      expect(JSON.stringify(wrapped(1))).toStrictEqual(JSON.stringify(ResultIs.success(2)));
+      expect(JSON.stringify(wrapped(1))).toStrictEqual(JSON.stringify(ok(2)));
     });
 
     it("should return Fail for errors", () => {
@@ -38,7 +27,7 @@ describe("withResult", () => {
       const asyncFunc = async (n: number) => n + 1;
       const wrapped = withResult(asyncFunc);
       const result = await wrapped(1);
-      expect(JSON.stringify(result)).toEqual(JSON.stringify(ResultIs.success(2)));
+      expect(JSON.stringify(result)).toEqual(JSON.stringify(ok(2)));
     });
 
     it("should return Fail for rejected promises", async () => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -37,6 +37,7 @@
   "exclude": [
     "node_modules",
     "./types",
-    "src/**/*.unit.test.ts"
+    "src/**/*.unit.test.ts",
+    "src/types-scratch-board.ts"
   ]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -988,15 +988,6 @@
   dependencies:
     "@jridgewell/trace-mapping" "0.3.9"
 
-"@es-joy/jsdoccomment@~0.31.0":
-  version "0.31.0"
-  resolved "https://registry.yarnpkg.com/@es-joy/jsdoccomment/-/jsdoccomment-0.31.0.tgz#dbc342cc38eb6878c12727985e693eaef34302bc"
-  integrity sha512-tc1/iuQcnaiSIUVad72PBierDFpsxdUHtEF/OrfqvM1CBAsIoMP51j52jTMb3dXriwhieTo289InzZj72jL3EQ==
-  dependencies:
-    comment-parser "1.3.1"
-    esquery "^1.4.0"
-    jsdoc-type-pratt-parser "~3.1.0"
-
 "@eslint/eslintrc@^1.3.3":
   version "1.3.3"
   resolved "https://registry.yarnpkg.com/@eslint/eslintrc/-/eslintrc-1.3.3.tgz#2b044ab39fdfa75b4688184f9e573ce3c5b0ff95"
@@ -1895,11 +1886,6 @@ commander@^4.0.1:
   resolved "https://registry.yarnpkg.com/commander/-/commander-4.1.1.tgz#9fd602bd936294e9e9ef46a3f4d6964044b18068"
   integrity sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==
 
-comment-parser@1.3.1:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/comment-parser/-/comment-parser-1.3.1.tgz#3d7ea3adaf9345594aedee6563f422348f165c1b"
-  integrity sha512-B52sN2VNghyq5ofvUsqZjmk6YkihBX5vMSChmSK9v4ShjKf3Vk5Xcmgpw4o+iIgtrnM/u5FiMpz9VKb8lpBveA==
-
 commondir@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/commondir/-/commondir-1.0.1.tgz#ddd800da0c66127393cca5950ea968a3aaf1253b"
@@ -2041,19 +2027,6 @@ eslint-config-prettier@^8.5.0:
   version "8.5.0"
   resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-8.5.0.tgz#5a81680ec934beca02c7b1a61cf8ca34b66feab1"
   integrity sha512-obmWKLUNCnhtQRKc+tmnYuQl0pFU1ibYJQ5BGhTVB08bHe9wC8qUeG7c08dj9XX+AuPj1YSGSQIHl1pnDHZR0Q==
-
-eslint-plugin-jsdoc@^39.3.6:
-  version "39.3.6"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-39.3.6.tgz#6ba29f32368d72a51335a3dc9ccd22ad0437665d"
-  integrity sha512-R6dZ4t83qPdMhIOGr7g2QII2pwCjYyKP+z0tPOfO1bbAbQyKC20Y2Rd6z1te86Lq3T7uM8bNo+VD9YFpE8HU/g==
-  dependencies:
-    "@es-joy/jsdoccomment" "~0.31.0"
-    comment-parser "1.3.1"
-    debug "^4.3.4"
-    escape-string-regexp "^4.0.0"
-    esquery "^1.4.0"
-    semver "^7.3.7"
-    spdx-expression-parse "^3.0.1"
 
 eslint-plugin-no-null@^1.0.2:
   version "1.0.2"
@@ -2993,11 +2966,6 @@ js-yaml@^4.1.0:
   dependencies:
     argparse "^2.0.1"
 
-jsdoc-type-pratt-parser@~3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-3.1.0.tgz#a4a56bdc6e82e5865ffd9febc5b1a227ff28e67e"
-  integrity sha512-MgtD0ZiCDk9B+eI73BextfRrVQl0oyzRG8B2BjORts6jbunj4ScKPcyXGTbB6eXL4y9TzxCm6hyeLq/2ASzNdw==
-
 jsesc@^2.5.1:
   version "2.5.2"
   resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-2.5.2.tgz#80564d2e483dacf6e8ef209650a67df3f0c283a4"
@@ -3584,24 +3552,6 @@ source-map@^0.6.0, source-map@^0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
   integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
-
-spdx-exceptions@^2.1.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/spdx-exceptions/-/spdx-exceptions-2.3.0.tgz#3f28ce1a77a00372683eade4a433183527a2163d"
-  integrity sha512-/tTrYOC7PPI1nUAgx34hUpqXuyJG+DTHJTnIULG4rDygi4xu/tfgmq1e1cIRwRzwZgo4NLySi+ricLkZkw4i5A==
-
-spdx-expression-parse@^3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz#cf70f50482eefdc98e3ce0a6833e4a53ceeba679"
-  integrity sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==
-  dependencies:
-    spdx-exceptions "^2.1.0"
-    spdx-license-ids "^3.0.0"
-
-spdx-license-ids@^3.0.0:
-  version "3.0.12"
-  resolved "https://registry.yarnpkg.com/spdx-license-ids/-/spdx-license-ids-3.0.12.tgz#69077835abe2710b65f03969898b6637b505a779"
-  integrity sha512-rr+VVSXtRhO4OHbXUiAF7xW3Bo9DuuF6C5jH+q/x15j2jniycgKbxU09Hr0WqlSLUs4i4ltHGXqTe7VHclYWyA==
 
 sprintf-js@~1.0.2:
   version "1.0.3"


### PR DESCRIPTION
It seems to me like `ResultIs.failure` and `ResultIs.success` have proven to be overly verbose and cumbersome for something that's used as frequently in a project as this ought to be.

This PR reverts things back to the much more ergonomic method for creating results in the functions `ok` and `err`