### PR TITLE
Adding `partitionResults`: a function for converting an array of results into its successes and failure in an easy-to-use way.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-error-as-value",
-  "version": "0.4.01",
+  "version": "0.4.02",
   "description": "Errors as values in typescript",
   "main": "lib/index.js",
   "keywords": ["result", "option", "rust", "kotlin", "errors", "errors as values", "typescript"],

--- a/src/globals.d.ts
+++ b/src/globals.d.ts
@@ -29,3 +29,24 @@ declare function withResult<
 ): (
   ...args: Parameters<F>
 ) => ReturnType<F> extends Promise<infer u> ? Promise<Result<u, E>> : Result<ReturnType<F>, E>;
+
+export interface PartitionedResults<T, E extends Error> {
+  data: T[],
+  errors: AggregateError | E | null
+}
+
+declare function partitionResults<T, E extends Error>(
+  results: Result<T, E>[]
+): PartitionedResults<T, E>;
+
+declare function partitionResults<T, E extends Error>(
+  results: Promise<Result<T, E>[]>
+): Promise<PartitionedResults<T, E>>;
+
+declare function partitionResults<T, E extends Error>(
+  results: Promise<Result<T, E>>[]
+): Promise<PartitionedResults<T, E>>;
+
+declare function partitionResults<T, E extends Error>(
+  results: Result<T, E>[]
+): PartitionedResults<T, E>;

--- a/src/globals.ts
+++ b/src/globals.ts
@@ -1,12 +1,15 @@
 import { ok, err } from ".";
 import { withResult } from "./with-result";
+import { partitionResults } from "./partition-results";
 
 if (typeof window !== "undefined") {
   (window as any).err = err;
   (window as any).ok = ok;
   (window as any).withResult = withResult;
+  (window as any).partitionResults = partitionResults;
 } else {
   (globalThis as any).err = err;
   (globalThis as any).ok = ok;
   (globalThis as any).withResult = withResult;
+  (globalThis as any).partitionResults = partitionResults;
 }

--- a/src/partition-results.ts
+++ b/src/partition-results.ts
@@ -1,0 +1,87 @@
+import { Result } from "./index";
+import { isPromise } from "./utils";
+
+export interface PartitionedResults<T, E extends Error> {
+  data: T[],
+  errors: AggregateError | E | null
+}
+
+const isResultArray = <T, E extends Error>(array: any[]): array is Result<T, E>[] =>
+  array.every(item => (item && "data" in item && "error" in item));
+
+const isPromiseResultArray = <T, E extends Error>(array: any[]): array is Promise<Result<T, E>>[] =>
+  array.every(isPromise);
+
+export function partitionResults<T, E extends Error>(
+  results: Result<T, E>[]
+): PartitionedResults<T, E>;
+
+export function partitionResults<T, E extends Error>(
+  results: Promise<Result<T, E>[]>
+): Promise<PartitionedResults<T, E>>;
+
+export function partitionResults<T, E extends Error>(
+  results: Promise<Result<T, E>>[]
+): Promise<PartitionedResults<T, E>>;
+
+/**
+ * @desc Takes in an array of Results, an array of promises of results, or a promise of an
+ * array of results, and returns an object with a data property containing an array of all
+ * the data from the results, and an errors property containing an AggregateError if there
+ * were multiple errors, a single error if there was only one, or null if there were no
+ * errors.
+ */
+export function partitionResults<T, E extends Error>(
+  results: Result<T, E>[] | Promise<Result<T, E>[]> | Promise<Result<T, E>>[]
+): PartitionedResults<T, E> | Promise<PartitionedResults<T, E>> {
+  const processResults = (results: Result<T, E>[]): PartitionedResults<T, E> => {
+    const data: T[] = [];
+    const errors: E[] = [];
+
+    for (const result of results) {
+      if (result.error) {
+        errors.push(result.error);
+      } else {
+        data.push(result.data as T);
+      }
+    }
+
+    let partitionedErrors: null | AggregateError | E = null;
+    if (errors.length > 1) {
+      partitionedErrors = new AggregateError(errors);
+    } else if (errors.length > 0) {
+      partitionedErrors = errors[0];
+    }
+
+    return {
+      data,
+      errors: partitionedErrors
+    };
+  };
+
+  // Check if results is a Promise
+  if (isPromise(results)) {
+    return results.then(resolvedResults => {
+      // Handle Promise<Result<T, E>[]>
+      if (Array.isArray(resolvedResults)) {
+        return processResults(resolvedResults);
+      } else {
+        return Promise.all(resolvedResults).then(processResults);
+      }
+    });
+  } else if (Array.isArray(results)) { // Check if results is a Promise[]
+    if (isResultArray(results)) {
+      // Handle Result<T, E>[]
+      return processResults(results);
+    } else if (isPromiseResultArray(results)) {
+      // Handle Promise<Result<T, E>>[]
+      return Promise.all(results).then(processResults);
+    }
+  }
+
+  // Handle Result<T, E>[]
+  return processResults(results);
+}
+
+
+

--- a/src/partition-results.unit.test.ts
+++ b/src/partition-results.unit.test.ts
@@ -1,0 +1,43 @@
+import { err, ok, Result } from "./index";
+import { PartitionedResults, partitionResults } from "./partition-results";
+
+describe("partitionResults", () => {
+  it("should partition array of Result objects correctly", () => {
+    const results: Result<number, Error>[] = [
+      ok(1),
+      err(new Error("Error 1")),
+      ok(2)
+    ];
+    const expected: PartitionedResults<number, Error> = {
+      data: [ 1, 2 ],
+      errors: new Error("Error 1")
+    };
+    expect(partitionResults(results)).toEqual(expected);
+  });
+
+  it("should handle promise resolving to Result array correctly", async () => {
+    const resultsPromise = Promise.resolve<Result<number, Error>[]>([
+      ok(3),
+      err(new Error("Error 2"))
+    ]);
+    const expected: PartitionedResults<number, Error> = {
+      data: [ 3 ],
+      errors: new Error("Error 2")
+    };
+    const result = await partitionResults(resultsPromise);
+    expect(result).toEqual(expected);
+  });
+
+  it("should handle array of promises resolving to Result objects correctly", async () => {
+    const results: Promise<Result<number, Error>>[] = [
+      Promise.resolve(ok(4)),
+      Promise.resolve(err(new Error("Error 3")))
+    ];
+    const expected: PartitionedResults<number, Error> = {
+      data: [ 4 ],
+      errors: new Error("Error 3")
+    };
+    const result = await partitionResults(results);
+    expect(result).toEqual(expected);
+  });
+});


### PR DESCRIPTION
Adding `partitionResults`: a function for converting an array of results into its successes and failure in an easy-to-use way.